### PR TITLE
Correct extraction of int64 in GetMultiPropertyAs

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -131,12 +131,18 @@ func (v Vertex) GetMultiPropertyAs(key, wantType string) (vals []interface{}, er
 			}
 			vals = append(vals, int32(val))
 		case "int64":
-			var val int64
-			if val, ok = prop.Value.Value.(int64); !ok {
-				err = ErrorUnexpectedPropertyType
-				return
+			var typeIf, valIf interface{}
+			if typeIf, ok = prop.Value.Value.(map[string]interface{})["@type"]; !ok || typeIf != "g:Int64" {
+				return vals, ErrorUnexpectedPropertyType
 			}
-			vals = append(vals, val)
+			if valIf, ok = prop.Value.Value.(map[string]interface{})["@value"]; !ok {
+				return vals, ErrorUnexpectedPropertyType
+			}
+			var val float64
+			if val, ok = valIf.(float64); !ok {
+				return vals, ErrorUnexpectedPropertyType
+			}
+			vals = append(vals, int64(val))
 		}
 	}
 	return

--- a/utils_test.go
+++ b/utils_test.go
@@ -19,6 +19,7 @@ func TestStringProperties(t *testing.T) {
 		ExpectMulti  map[string][]string
 		ExpectMeta   map[string]map[string][]string
 		ExpectInt32  map[string][]int32
+		ExpectInt64  map[string][]int64
 		ExpectBool   map[string][]bool
 	}
 	exStr := map[string][]string{"tSimple": {"tSimple"}, "tMulti": {"tMulti1", "tMulti2"}, "tMeta": {"tMeta1", "tMeta2"}}
@@ -42,6 +43,13 @@ func TestStringProperties(t *testing.T) {
 						{Type: "g:VertexProperty",
 							Value: VertexPropertyValue{ID: genericID, Label: "counter",
 								Value: map[string]interface{}{"@type": "g:Int32", "@value": float64(1234)},
+							},
+						},
+					},
+					"big-counter": {
+						{Type: "g:VertexProperty",
+							Value: VertexPropertyValue{ID: genericID, Label: "big-counter",
+								Value: map[string]interface{}{"@type": "g:Int64", "@value": float64(1234)},
 							},
 						},
 					},
@@ -104,6 +112,7 @@ func TestStringProperties(t *testing.T) {
 			ExpectMulti:  map[string][]string{p: exStr["tSimple"]},
 			ExpectMeta:   map[string]map[string][]string{p: {p: exStr["tSimple"]}},
 			ExpectInt32:  map[string][]int32{"counter": {1234}},
+			ExpectInt64:  map[string][]int64{"big-counter": {1234}},
 			ExpectBool:   map[string][]bool{"George": {true}},
 		},
 		{Label: "tMulti",
@@ -159,6 +168,12 @@ func TestStringProperties(t *testing.T) {
 
 			for key, expectedVals := range expected.ExpectInt32 {
 				gotVals, err := given.GetMultiPropertyInt32(key)
+				So(err, ShouldBeNil)
+				So(gotVals, ShouldResemble, expectedVals)
+			}
+
+			for key, expectedVals := range expected.ExpectInt64 {
+				gotVals, err := given.GetMultiPropertyInt64(key)
 				So(err, ShouldBeNil)
 				So(gotVals, ShouldResemble, expectedVals)
 			}


### PR DESCRIPTION
Specifically treat it with the same pattern is that for int32 - i.e.
anticipate a map not a plain value.

The existing code treated int32 and int64 differently. Int32 expected to find a graphson map, whereas int64 expected to find a plain value. The int32 pattern is the correct one, so this commit changes it thus.

There was test coverage for the int32 case, but not for the int64 case, so this commit added that too.

All that is necessary to validate the change is to run the package's unit tests.