### PR TITLE
Tolerate int32 value in database when reading into an int64

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -131,10 +131,12 @@ func (v Vertex) GetMultiPropertyAs(key, wantType string) (vals []interface{}, er
 			}
 			vals = append(vals, int32(val))
 		case "int64":
-			var typeIf, valIf interface{}
-			if typeIf, ok = prop.Value.Value.(map[string]interface{})["@type"]; !ok || typeIf != "g:Int64" {
+			typedPropValue := prop.Value.Value.(map[string]interface{})
+			typeAsString, ok := typedPropValue["@type"]
+			if !ok || (typeAsString != "g:Int64" && typeAsString != "g:Int32") {
 				return vals, ErrorUnexpectedPropertyType
 			}
+			var valIf interface{}
 			if valIf, ok = prop.Value.Value.(map[string]interface{})["@value"]; !ok {
 				return vals, ErrorUnexpectedPropertyType
 			}


### PR DESCRIPTION
The graphson payload that represent int64 and int32 typed values from the database, is a map that contains a string representation of the type, and a separate value field. 
The existing code for reading an int64 requires that this string representation of the type is g:Int42.

This change relaxes that requirement to tolerate also the string being g:Int64.

This use case was discovered by a client wishing to de-serialize such a payload into a structure with an int64 field. The value had been created in the database using a neptune query that set an integer property with an integer constant value, where it is impossible to force it to be made as an int64.

