### PR TITLE
Fix/empty slice responses

### DIFF
--- a/deserialize.go
+++ b/deserialize.go
@@ -35,11 +35,14 @@ func DeserializeVerticesFromBytes(rawResponse []byte) ([]Vertex, error) {
 
 // DeserializeListOfVerticesFromBytes returns a slice of Vertex from the graphson rawResponse g:List of vertex
 func DeserializeListOfVerticesFromBytes(rawResponse []byte) ([]Vertex, error) {
+
+	if isEmptyResponse(rawResponse) {
+		return []Vertex{}, nil
+	}
+
 	var metaResponse ListVertices
 	var response []Vertex
-	if len(rawResponse) == 0 {
-		return response, nil
-	}
+
 	dec := json.NewDecoder(bytes.NewReader(rawResponse))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&metaResponse); err != nil {
@@ -54,11 +57,14 @@ func DeserializeListOfVerticesFromBytes(rawResponse []byte) ([]Vertex, error) {
 }
 
 func DeserializeListOfEdgesFromBytes(rawResponse []byte) (Edges, error) {
+
+	if isEmptyResponse(rawResponse) {
+		return Edges{}, nil
+	}
+
 	var metaResponse ListEdges
 	var response Edges
-	if len(rawResponse) == 0 {
-		return response, nil
-	}
+
 	dec := json.NewDecoder(bytes.NewReader(rawResponse))
 	dec.DisallowUnknownFields()
 	err := dec.Decode(&metaResponse)
@@ -74,10 +80,13 @@ func DeserializeListOfEdgesFromBytes(rawResponse []byte) (Edges, error) {
 }
 
 func DeserializeMapFromBytes(rawResponse []byte) (resMap map[string]interface{}, err error) {
-	var metaResponse GList
-	if len(rawResponse) == 0 {
-		return
+
+	if isEmptyResponse(rawResponse) {
+		return map[string]interface{}{}, nil
 	}
+
+	var metaResponse GList
+
 	dec := json.NewDecoder(bytes.NewReader(rawResponse))
 	dec.DisallowUnknownFields()
 	if err = dec.Decode(&metaResponse); err != nil {
@@ -124,13 +133,16 @@ func DeserializePropertiesFromBytes(rawResponse []byte, resMap map[string][]inte
 
 // DeserializeStringListFromBytes get a g:List value which should be a a list of strings, return those
 func DeserializeStringListFromBytes(rawResponse []byte) (vals []string, err error) {
-	var metaResponse GList
-	if len(rawResponse) == 0 {
-		err = errors.New("DeserializeStringListFromBytes: nothing to decode")
+
+	if isEmptyResponse(rawResponse) {
+		vals = []string{}
 		return
 	}
+
 	dec := json.NewDecoder(bytes.NewReader(rawResponse))
 	dec.DisallowUnknownFields()
+
+	var metaResponse GList
 	if err = dec.Decode(&metaResponse); err != nil {
 		return
 	}
@@ -246,4 +258,12 @@ func ConvertToCleanEdges(edges Edges) []CleanEdge {
 		})
 	}
 	return responseEdges
+}
+
+func isEmptyResponse(rawResponse []byte) bool {
+	return len(rawResponse) == 0 || isNullResponse(rawResponse)
+}
+
+func isNullResponse(rawResponse []byte) bool {
+	return len(rawResponse) == 4 && string(rawResponse) == "null"
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/ONSdigital/graphson
+
+go 1.14
+
+require github.com/smartystreets/goconvey v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 h1:TFlARGu6Czu1z7q93HTxcP1P+/ZFC/IKythI5RzrnRg=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=


### PR DESCRIPTION
- Use go modules
- Ensure empty responses are mapped to empty slices instead of returning err. 
    - Functions that return a slice or map were returning an error if the response was empty / null.